### PR TITLE
Fix: adapter miniprogram bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/miniprogram-adapter",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "adapter of miniprogram",
   "keywords": [
     "webgl",

--- a/src/XMLHttpRequest.ts
+++ b/src/XMLHttpRequest.ts
@@ -180,12 +180,16 @@ export class XMLHttpRequest extends EventTarget {
         _triggerEvent.call(this, "loadend");
       };
 
+      if (!this.timeout || this.timeout === Infinity) {
+        this.timeout = 30000;
+      }
+
       let requestTask = my.request({
         enableCCDNCache: true,
         data,
         url,
         method: this._method,
-        timeout: this.timeout ? this.timeout : 30000,
+        timeout: this.timeout,
         headers: header,
         dataType: responseType,
         success: onSuccess,


### PR DESCRIPTION
端会把 `Infinity` 解析成  `<null>` , 由于影响范围广时间长，此处做个兼容，等待端修复这个问题后移除。